### PR TITLE
Eslisp 0.7

### DIFF
--- a/index.esl
+++ b/index.esl
@@ -8,13 +8,17 @@
     (=== x.type "atom")
     (=== 0 (x.value.indexOf "..."))))))
 
-(function array-to-list (arr) (return (object
-  "type" "list"
-  "values" arr)))
+(function array-to-list (arr) 
+  (return (object
+    "type" "list"
+    "values" arr)))
 
 (= module.exports
    (lambda
      ()
+
+    ;; We'll need this later when we are inside a function with a different this...
+     (var atom this.atom)
 
      (var prepend-statements (array))
 
@@ -42,7 +46,7 @@
 
                  ; Splat is the only argument: just slice all
                  ((== (+ before-splat.length after-splat.length) 0)
-                  (var splat-slice-call `(var ,(this.atom splat-name)
+                  (var splat-slice-call `(var ,(atom splat-name)
                                               ((. Array prototype slice call)
                                                arguments)))
                   (prepend-statements.push splat-slice-call)
@@ -50,10 +54,10 @@
 
                  ; Splat is last argument: slice from there to end
                  ((== after-splat.length 0)
-                  (var splat-slice-call `(var ,(this.atom splat-name)
+                  (var splat-slice-call `(var ,(atom splat-name)
                                               ((. Array prototype slice call)
                                                arguments 
-                                               ,(this.atom before-splat.length))))
+                                               ,(atom before-splat.length))))
                   (prepend-statements.push splat-slice-call)
                   (break))
 
@@ -63,16 +67,14 @@
                    (var splat-start before-splat.length)
                    (var splat-end (- after-splat.length))
                    (var splat-slice-call
-                        `(var ,(this.atom splat-name)
+                        `(var ,(atom splat-name)
                               ((. Array prototype slice call)
-                               arguments ,(this.atom splat-start) 
-                               ,(this.atom splat-end))))
+                               arguments ,(atom splat-start) 
+                               ,(atom splat-end))))
 
                    (prepend-statements.push splat-slice-call)
 
 
-                   ;; Hoist atom creator
-                   (var atom this.atom)
                    (after-splat.for-each
                      (lambda (x i)
                        (prepend-statements.push

--- a/index.esl
+++ b/index.esl
@@ -1,7 +1,16 @@
 (var prelude (require "prelude-ls"))
 (var break-list prelude.break-list)
+(var esutils (require "esutils"))
 
-(var is-splat (lambda (x) (return (== 0 (x.atom.indexOf "...")))))
+(var is-splat (lambda (x) 
+  (return (&& 
+    (=== (typeof x) "object")
+    (=== x.type "atom")
+    (=== 0 (x.value.indexOf "..."))))))
+
+(function array-to-list (arr) (return (object
+  "type" "list"
+  "values" arr)))
 
 (= module.exports
    (lambda
@@ -13,7 +22,7 @@
      (var function-args args.0)
      (var function-body (args.slice 1))
 
-     (var break-results (break-list is-splat function-args))
+     (var break-results (break-list is-splat function-args.values))
 
      (var before-splat break-results.0)
 
@@ -28,12 +37,12 @@
      (if splat
        (block
          (var after-splat (splat-and-after.slice 1))
-         (var splat-name (splat.atom.slice 3))
+         (var splat-name (splat.value.slice 3))
          (switch true
 
                  ; Splat is the only argument: just slice all
                  ((== (+ before-splat.length after-splat.length) 0)
-                  (var splat-slice-call `(var ,(object atom splat-name)
+                  (var splat-slice-call `(var ,(this.atom splat-name)
                                               ((. Array prototype slice call)
                                                arguments)))
                   (prepend-statements.push splat-slice-call)
@@ -41,9 +50,10 @@
 
                  ; Splat is last argument: slice from there to end
                  ((== after-splat.length 0)
-                  (var splat-slice-call `(var ,(object atom splat-name)
+                  (var splat-slice-call `(var ,(this.atom splat-name)
                                               ((. Array prototype slice call)
-                                               arguments ,before-splat.length)))
+                                               arguments 
+                                               ,(this.atom before-splat.length))))
                   (prepend-statements.push splat-slice-call)
                   (break))
 
@@ -53,27 +63,34 @@
                    (var splat-start before-splat.length)
                    (var splat-end (- after-splat.length))
                    (var splat-slice-call
-                        `(var ,(object atom splat-name)
+                        `(var ,(this.atom splat-name)
                               ((. Array prototype slice call)
-                               arguments ,splat-start ,splat-end)))
+                               arguments ,(this.atom splat-start) 
+                               ,(this.atom splat-end))))
 
                    (prepend-statements.push splat-slice-call)
 
+
+                   ;; Hoist atom creator
+                   (var atom this.atom)
                    (after-splat.for-each
                      (lambda (x i)
                        (prepend-statements.push
-                         `(var ,x (. arguments
+                         `(var ,x (get arguments
                                      (- arguments.length
-                                        ,(- after-splat.length i)))))))
+                                        ,(atom (- after-splat.length i))))))))
                    ))))
 
      ; If the last thing is an expression, add an implicit "return"
      (var last-thing-in-body (function-body.pop))
      (if last-thing-in-body ; Just in case the function body was empty
        (block
-         (var last-converted (?: (this.is-expr last-thing-in-body)
+         (var last-converted (?: (esutils.ast.is-expression 
+                                   (this.compile last-thing-in-body))
                                  `(return ,last-thing-in-body)
                                  last-thing-in-body))
          (function-body.push last-converted)))
 
-     (return `(lambda ,before-splat ,@prepend-statements ,@function-body))))
+     (return `(lambda ,(array-to-list before-splat) 
+       ,@(array-to-list prepend-statements) 
+       ,@(array-to-list function-body)))))

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "tests-ex-markdown": "^2.0.0"
   },
   "peerDependencies": {
-    "eslisp": "0.6.x"
+    "eslisp": ">=0.7.5"
   },
   "dependencies": {
     "prelude-ls": "^1.1.2"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.2.0",
   "description": "eslisp function macro with rest arguments and implicit return",
   "main": "index.js",
-  "keywords": ["eslisp-macro"],
+  "keywords": [
+    "eslisp-macro"
+  ],
   "repository": "anko/eslisp-fancy-function",
   "scripts": {
     "test": "make test",
@@ -13,9 +15,9 @@
   "author": "Anko <an@cyan.io> (http://an.cyan.io)",
   "license": "ISC",
   "devDependencies": {
-    "eslisp": "^0.6.0",
-    "eslisp-camelify": "^0.1.3",
-    "eslisp-propertify": "^0.1.4",
+    "eslisp": "^0.7.6",
+    "eslisp-camelify": "^0.4.0",
+    "eslisp-propertify": "^0.3.0",
     "tape": "^4.0.0",
     "tests-ex-markdown": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "version": "0.2.0",
   "description": "eslisp function macro with rest arguments and implicit return",
   "main": "index.js",
-  "keywords": [
-    "eslisp-macro"
-  ],
+  "keywords": [ "eslisp-macro" ],
   "repository": "anko/eslisp-fancy-function",
   "scripts": {
     "test": "make test",


### PR DESCRIPTION
Hi there, been lurking for a while and I think I have finally wrapped my head around the compiler API enough to be useful. So I thought I'd tackle fixing this library. As far as I can tell this brings things up to date, but there could certainly be something I'm missing.

Main points:
1. Seems that lists went from being arrays to objects of the form:
```js
{
    type: "list"
    values: [...forms]
}
```
2. Seems that compiling raw numbers used to work but now they need to be atoms
3. Pulled `isExpression` from `esutils`, seems like there used to be a function on the `env` object.